### PR TITLE
Remove typing dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,6 @@ setup(
         "requests",
         "loguru",
         "typer",
-        "typing",
     ],
     extras_requires={
         "auth_with_selenium": [


### PR DESCRIPTION
The typing project is archived, typing module is part of the Python standard library as of version 3.5.

Reference: https://pypi.org/project/typing/